### PR TITLE
Add worflow to build miplib-backends image

### DIFF
--- a/.github/workflows/on_push_action.yml
+++ b/.github/workflows/on_push_action.yml
@@ -16,4 +16,3 @@ jobs:
         build-dir: ${{ runner.workspace }}/build
         build-type: Release
         run-test: true
-        

--- a/.github/workflows/update_backends.yml
+++ b/.github/workflows/update_backends.yml
@@ -1,0 +1,19 @@
+name: Backends Docker Image
+
+on:
+  # Weekly on Sunday at midnight
+  schedule:
+    - cron: '0 0 * * 0'
+  # Manually through the GitHub UI
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_PROJECT: gnosispm/miplib-backends
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: docker/deploy.sh ${GITHUB_REF#refs/*/}

--- a/.github/workflows/update_backends.yml
+++ b/.github/workflows/update_backends.yml
@@ -1,9 +1,12 @@
 name: Backends Docker Image
 
 on:
-  # Weekly on Sunday at midnight
+  # Weekly on Sunday at 00:42
   schedule:
-    - cron: '0 0 * * 0'
+    - cron: '42 0 * * 0'
+  # On new version tags
+  push:
+    tags: [v*]
   # Manually through the GitHub UI
   workflow_dispatch:
 

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+label="${1:-latest}"
+tag="$DOCKERHUB_PROJECT:$1"
+
+echo "$DOCKERHUB_PASSWORD" | \
+  docker login -u "$DOCKERHUB_USER" --password-stdin
+
+# Build and tag image
+docker build --pull -t $tag -f docker/Dockerfile.binary .
+docker push $tag


### PR DESCRIPTION
This PR adds a workflow to periodically build the `miplib-backends` docker image and publish it to Docker hub. The motivation here is to:
- Automate the process to make sure we keep up to date with Ubuntu security updates in the `miplib-backends` image
- Allow the image to be re-built and published manually through the GitHub UI
- Publish images on tags.

Before merging, we would need to ask DevOps to configure the secrets for this repo correctly.