### PR TITLE
Use docker login action

### DIFF
--- a/.github/workflows/update_backends.yml
+++ b/.github/workflows/update_backends.yml
@@ -15,8 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKERHUB_PROJECT: gnosispm/miplib-backends
-      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
-      DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
       - uses: actions/checkout@v2
+      - uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - run: docker/deploy.sh ${GITHUB_REF#refs/*/}

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -5,9 +5,6 @@ set -euo pipefail
 label="${1:-latest}"
 tag="$DOCKERHUB_PROJECT:$1"
 
-echo "$DOCKERHUB_PASSWORD" | \
-  docker login -u "$DOCKERHUB_USER" --password-stdin
-
 # Build and tag image
 docker build --pull -t $tag -f docker/Dockerfile .
 docker push $tag


### PR DESCRIPTION
This PR changes the CI for deploying the docker image to login using the `login-docker` action to avoid the:
```
WARNING! Your password will be stored unencrypted in /home/runner/.docker/config.json.
```

Warning.