### PR TITLE
Fix compiler warnings

### DIFF
--- a/miplib/expr.cpp
+++ b/miplib/expr.cpp
@@ -2,6 +2,7 @@
 #include "expr.hpp"
 #include "solver.hpp"
 
+#include <set>
 #include <fmt/ostream.h>
 
 namespace miplib {

--- a/miplib/lazy.hpp
+++ b/miplib/lazy.hpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <miplib/var.hpp>
 #include <miplib/constr.hpp>
+#include <vector>
 
 namespace miplib {
 

--- a/miplib/solver.hpp
+++ b/miplib/solver.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <map>
 
 #include "var.hpp"
 #include "constr.hpp"

--- a/miplib/util.hpp
+++ b/miplib/util.hpp
@@ -2,6 +2,7 @@
 
 #include <boost/container_hash/hash.hpp>
 #include <unordered_map>
+#include <vector>
 
 #include "var.hpp"
 

--- a/miplib/var.hpp
+++ b/miplib/var.hpp
@@ -29,8 +29,6 @@ struct Var
 
   Var(Solver const& solver, Var::Type const& type, std::string const& name);
 
-  Var(Var const& v) = default;
-
   bool is_same(Var const& v1) const;
 
   bool is_lex_less(Var const& v1) const;


### PR DESCRIPTION
While trying to build quasimodo locally with the latest apple clang version it pointed out some warnings which caused the compilation to fail due to `-Werror`.
This PR fixes those (mostly missing includes).