### PR TITLE
Hopefully fix macOS build without breaking CI

### DIFF
--- a/.github/workflows/on_push_action.yml
+++ b/.github/workflows/on_push_action.yml
@@ -1,6 +1,6 @@
 name: C/C++ CI
 
-on: [push]
+on: [push,pull_request]
 
 jobs:
   ubuntu-build-and-test:

--- a/miplib/CMakeLists.txt
+++ b/miplib/CMakeLists.txt
@@ -122,4 +122,7 @@ target_compile_options(${PROJECT_NAME} PUBLIC ${COMPILE_FLAGS})
 
 target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
 
+find_package(Boost CONFIG REQUIRED)
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${Boost_INCLUDE_DIRS})
+
 target_link_libraries(${PROJECT_NAME} ${LIBS})


### PR DESCRIPTION
The last [commit](https://github.com/gnosis/gp-v2-solver-lib/commit/32da6da2baa74295108fbb4a69676ddb9df73c5a) I prepared to fix the macOS build caused the CI build of the quasimodo repo to break.

What broke the CI of the other repo was that the build script now searches for boost on 2 occasions. Since boost is only a dependency of this library I moved the `find_package()` call here.
To make sure I don't break this repo's CI I also added a github action that builds every pull request.